### PR TITLE
Restore backward compatibility on ClearWindows

### DIFF
--- a/SimpleBrowser.UnitTests/OfflineTests/WindowsAndFrames.cs
+++ b/SimpleBrowser.UnitTests/OfflineTests/WindowsAndFrames.cs
@@ -150,5 +150,23 @@ namespace SimpleBrowser.UnitTests.OfflineTests
 			Assert.That(b.Frames.First().Url == new Uri("http://localhost/bla.htm"));
 
 		}
-	}
+        [Test]
+        public void Static_scoped_clear_works()
+        {
+            Browser b1 = new Browser(Helper.GetFramesMock());
+            Browser b2 = new Browser(Helper.GetFramesMock());
+            Browser.ClearWindows();
+            Assert.Throws(typeof(ObjectDisposedException), () => b1.Navigate("http://localhost/"));
+        }
+        [Test]
+        public void Instance_scoped_clear_works()   
+        {
+            Browser b1 = new Browser(Helper.GetFramesMock());
+            Browser b2 = new Browser(Helper.GetFramesMock());
+            b2.ClearWindowsInContext();
+            b1.Navigate("http://localhost/");
+            Assert.That(b1.Url.ToString() == "http://localhost/");
+            Assert.Throws(typeof(ObjectDisposedException), () => b2.Navigate("http://localhost/"));
+        }
+    }
 }

--- a/SimpleBrowser/Browser.cs
+++ b/SimpleBrowser/Browser.cs
@@ -289,11 +289,19 @@ namespace SimpleBrowser
 			LastWebException = null;
 		}
 
-		public void ClearWindows()
+		public void ClearWindowsInContext()
 		{
             foreach (var window in _allWindows.ToArray()) window.Close();
 			_allWindows.Clear();
 		}
+        public static void ClearWindows()
+        {
+            foreach (var list in _allContexts.ToArray())
+            {
+                foreach (var window in list.ToArray()) window.Close();
+            }
+            _allContexts.Clear();
+        }
 
 		public void Close()
 		{
@@ -1281,11 +1289,15 @@ namespace SimpleBrowser
 		private void Register(Browser browser)
 		{
 			_allWindows.Add(browser);
+            if(!_allContexts.Contains(_allWindows)){
+                _allContexts.Add(_allWindows);
+            }
 			if (browser.WindowHandle == null)
 			{
 				browser.WindowHandle = Guid.NewGuid().ToString().Substring(0, 8);
 			}
 		}
+        private static List<List<Browser>> _allContexts = new List<List<Browser>>();
 
 		#endregion private methods end
     }


### PR DESCRIPTION
@kevingy  ,
Please review. If it is OK, you can pull and I will create a new version on nuget later today.

Reintroduced static ClearWindows
Had to rename instance scoped ClearWindows to ClearWindowsInContext
Added unit tests