### PR TITLE
Handle malformed HTML and hidden charset input.

### DIFF
--- a/SimpleBrowser.UnitTests/OfflineTests/Forms.cs
+++ b/SimpleBrowser.UnitTests/OfflineTests/Forms.cs
@@ -6,12 +6,9 @@
 
 namespace SimpleBrowser.UnitTests.OfflineTests
 {
-	using System;
 	using System.Collections.Generic;
 	using System.Linq;
-	using System.Xml;
 	using System.Xml.Linq;
-	using System.Text;
 	using NUnit.Framework;
 
 	/// <summary>
@@ -20,6 +17,52 @@ namespace SimpleBrowser.UnitTests.OfflineTests
 	[TestFixture]
 	public class Forms
 	{
+		[Test]
+		public void Forms_Malformed_Select()
+		{
+			Browser b = new Browser();
+			b.SetContent(Helper.GetFromResources("SimpleBrowser.UnitTests.SampleDocs.SimpleForm.htm"));
+
+			// Test the malformed option.
+			HtmlResult options = b.Find("malformedOption1");
+			Assert.IsNotNull(options);
+			Assert.IsTrue(options.Exists);
+
+			options.Value = "3";
+			Assert.That(options.Value == "3");
+
+			// Test the malformed option group
+			IEnumerable<XElement> groups = options.XElement.Elements("optgroup");
+			Assert.That(groups.Count() == 2);
+
+			XElement group = groups.First();
+			Assert.That(group.Elements("option").Count() == 4);
+
+			group = groups.ElementAt(1);
+			Assert.That(group.Elements("option").Count() == 3);
+
+			options = b.Find("malformedOption2");
+			Assert.IsNotNull(options);
+			Assert.IsTrue(options.Exists);
+
+			options.Value = "3";
+			Assert.That(options.Value != "3");
+			Assert.That(options.Value == "4");
+
+			options.Value = "V";
+			Assert.That(options.Value == "V");
+
+			// Test the malformed option group
+			groups = options.XElement.Elements("optgroup");
+			Assert.That(groups.Count() == 2);
+
+			group = groups.First();
+			Assert.That(group.Elements("option").Count() == 2);
+
+			group = groups.ElementAt(1);
+			Assert.That(group.Elements("option").Count() == 5);
+		}
+
 		/// <summary>
 		/// Tests that input elements that handle the maxlength attribute correctly set the value of the attribute.
 		/// </summary>

--- a/SimpleBrowser.UnitTests/SampleDocs/SimpleForm.htm
+++ b/SimpleBrowser.UnitTests/SampleDocs/SimpleForm.htm
@@ -1,19 +1,43 @@
 <!DOCTYPE html>
 <html>
-
-
   <body >
   <form action="http://localhost/test" method=get>
+    <input type="hidden" name="_charset_" />
+
+    <select id="malformedOption1">
+    <optgroup>
+    <option>0
+    <option>1
+    <option>2
+    <option>3
+    <optgroup>
+    <option>A
+    <option>B
+    <option>C
+    <select id="malformedOption2">
+    <optgroup>
+    <option>4
+    <option>5
+    </optgroup>
+    <optgroup>
+    <option>V
+    <option>W
+    <option>X
+    <option>Y
+    <option>Z
+    </optgroup>
+    </select>
+
     <div class="cb-container">
-    <input name="cb" id="first-checkbox" type=checkbox checked=checked /> <label for="first-checkbox">first</label> 
-    <input name="cb" id="second-checkbox" type=checkbox /> <label for="second-checkbox">second</label> 
-
+    <input name="cb" id="first-checkbox" type=checkbox checked=checked /> <label for="first-checkbox">first</label>
+    <input name="cb" id="second-checkbox" type=checkbox /> <label for="second-checkbox">second</label>
     </div>
+
     <div class="rb-container">
-    <input name="radios" id="first-radio" type=radio checked=checked value="first"/> <label for="first-radio">first</label> 
-    <input name="radios" id="second-radio" type=radio  value="second"/> <label for="second-radio">second</label> 
-
+    <input name="radios" id="first-radio" type=radio checked=checked value="first"/> <label for="first-radio">first</label>
+    <input name="radios" id="second-radio" type=radio  value="second"/> <label for="second-radio">second</label>
     </div>
+
     <input type="text" name="textbox" value="textbox content" />
     <textarea name="textarea_a" readonly=readonly>This is a full text part
 with several line

--- a/SimpleBrowser/Browser.cs
+++ b/SimpleBrowser/Browser.cs
@@ -24,7 +24,7 @@ namespace SimpleBrowser
 		internal const string TARGET_BLANK = "_blank";
 		const string TARGET_TOP = "_top";
 
-	    private readonly List<Browser> _allWindows;
+		private readonly List<Browser> _allWindows;
 
 		private HashSet<string> _extraHeaders = new HashSet<string>();
 		private readonly List<HtmlElement> _allActiveElements = new List<HtmlElement>();
@@ -38,7 +38,7 @@ namespace SimpleBrowser
 		private HttpRequestLog _lastRequestLog;
 		private List<LogItem> _logs = new List<LogItem>();
 		private readonly IWebRequestFactory _reqFactory;
-	    private readonly Dictionary<string, BasicAuthenticationToken> _basicAuthenticationTokens;
+		private readonly Dictionary<string, BasicAuthenticationToken> _basicAuthenticationTokens;
 		private NameValueCollection _navigationAttributes = null;
 
 		static Browser()
@@ -53,7 +53,7 @@ namespace SimpleBrowser
 
 		public Browser(IWebRequestFactory requestFactory = null, string name = null, List<Browser> context = null)
 		{
-            _allWindows = context ?? new List<Browser>();
+			_allWindows = context ?? new List<Browser>();
 			AutoRedirect = true;
 			UserAgent = "SimpleBrowser (http://github.com/axefrog/SimpleBrowser)";
 			RetainLogs = true;
@@ -62,7 +62,7 @@ namespace SimpleBrowser
 			if (requestFactory == null)
 				requestFactory = new DefaultRequestFactory();
 			_reqFactory = requestFactory;
-            _basicAuthenticationTokens = new Dictionary<string, BasicAuthenticationToken>();
+			_basicAuthenticationTokens = new Dictionary<string, BasicAuthenticationToken>();
 			WindowHandle = name;
 			this.Register(this);
 		}
@@ -291,7 +291,7 @@ namespace SimpleBrowser
 
 		public void ClearWindows()
 		{
-            foreach (var window in _allWindows.ToArray()) window.Close();
+			foreach (var window in _allWindows.ToArray()) window.Close();
 			_allWindows.Clear();
 		}
 
@@ -630,7 +630,7 @@ namespace SimpleBrowser
 
 		internal Browser CreateChildBrowser(string name = null)
 		{
-            Browser child = new Browser(_reqFactory, name, _allWindows);
+			Browser child = new Browser(_reqFactory, name, _allWindows);
 			child.ParentWindow = this;
 			// no RaiseNewWindowOpened here, because it is not really a new window. It can be navigated to using 
 			// the frames collection of the parent
@@ -768,6 +768,11 @@ namespace SimpleBrowser
 						if (method == "GET")
 							throw new InvalidOperationException("Cannot call DoRequest with method GET and non-null postData");
 						postBody = postData;
+						// 28591 corresponds to ISO-8859-1, the default encoding of an HTTP POST.
+						// http://msdn.microsoft.com/en-us/library/system.text.encodinginfo.getencoding%28v=vs.110%29.aspx
+						// In the event that this value ever changes, including no longer being hard coded,
+						// update the encoding being sent with a form submission with a hidden input named _charset_
+						// in InputElement.cs.
 						byte[] data = Encoding.GetEncoding(28591).GetBytes(postData);
 						req.ContentLength = data.Length;
 						using (Stream stream = req.GetRequestStream())
@@ -829,7 +834,7 @@ namespace SimpleBrowser
 							}
 							
 							if (AutoRedirect == true &&
-							        (((int)response.StatusCode == 300 || // Not entirely supported. If provided, the server's preference from the Location header is honored.
+									(((int)response.StatusCode == 300 || // Not entirely supported. If provided, the server's preference from the Location header is honored.
 								(int)response.StatusCode == 301 ||
 								(int)response.StatusCode == 302 ||
 								(int)response.StatusCode == 303 ||
@@ -1288,7 +1293,7 @@ namespace SimpleBrowser
 		}
 
 		#endregion private methods end
-    }
+	}
 }
 
 

--- a/SimpleBrowser/Elements/InputElement.cs
+++ b/SimpleBrowser/Elements/InputElement.cs
@@ -81,7 +81,14 @@ namespace SimpleBrowser.Elements
 		{
 			if (!String.IsNullOrEmpty(this.Name))
 			{
-				yield return new UserVariableEntry() { Name = this.Name, Value = this.Value };
+				if (this.Name.Equals("_charset_") && string.IsNullOrEmpty(this.Value) && this.InputType.Equals("hidden", StringComparison.OrdinalIgnoreCase))
+				{
+					yield return new UserVariableEntry() { Name = this.Name, Value = "iso-8859-1" };
+				}
+				else
+				{
+					yield return new UserVariableEntry() { Name = this.Name, Value = this.Value };
+				}
 			}
 			yield break;
 		}


### PR DESCRIPTION
Handle malformed HTML for select, optgroup, and option tags where if the tags are not closed, the tags were parsed as being nested rather than siblings. Also added support for the hidden _charset_ input, per the HTML5 spec.