### PR TITLE
Fix to cookie handling of commas

### DIFF
--- a/SimpleBrowser.UnitTests/InternalTests/SetCookieHeaderParserTests.cs
+++ b/SimpleBrowser.UnitTests/InternalTests/SetCookieHeaderParserTests.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using NUnit.Framework;
+using SimpleBrowser.Internal;
+
+namespace SimpleBrowser.UnitTests.InternalTests
+{
+    [TestFixture]
+    public class SetCookieHeaderParserTests
+    {
+        [Test]
+        public void KeyValueCookie_ParsesNameValueCorrectly()
+        {
+            var actual = SetCookieHeaderParser.GetAllCookiesFromHeader("test.com", "theme=light");
+            Assert.That(actual.Count, Is.EqualTo(1));
+            Assert.That(actual[0].Name, Is.EqualTo("theme"));
+            Assert.That(actual[0].Value, Is.EqualTo("light"));
+        }
+
+        [Test]
+        public void KeyValueCookie_StripsCarriageReturns()
+        {
+            var actual = SetCookieHeaderParser.GetAllCookiesFromHeader("test.com", "theme=light\r\n");
+            Assert.That(actual.Count, Is.EqualTo(1));
+            Assert.That(actual[0].Name, Is.EqualTo("theme"));
+            Assert.That(actual[0].Value, Is.EqualTo("light"));
+        }
+
+        [Test]
+        public void KeyOnlyCookie_ParsesNameValueCorrectly()
+        {
+            var actual = SetCookieHeaderParser.GetAllCookiesFromHeader("test.com", "theme");
+            Assert.That(actual.Count, Is.EqualTo(1));
+            Assert.That(actual[0].Name, Is.EqualTo("theme"));
+            Assert.That(actual[0].Value, Is.EqualTo(""));
+        }
+
+        [Test]
+        public void CookieWithNoDomain_UsesDefaultDomain()
+        {
+            const string testDomain = "test.com";
+            const string cookieHeader = "theme";
+            var actual = SetCookieHeaderParser.GetAllCookiesFromHeader(testDomain, cookieHeader);
+            Assert.That(actual[0].Domain, Is.EqualTo(testDomain));
+        }
+
+        [Test]
+        public void CookieWithDomain_UsesAssignedDomain()
+        {
+            const string testDomain = "test.com";
+            const string cookieHeader = "sessionToken=abc123; Domain=.cookie-specified.com";
+            var actual = SetCookieHeaderParser.GetAllCookiesFromHeader(testDomain, cookieHeader);
+            Assert.That(actual[0].Domain, Is.EqualTo(".cookie-specified.com"));
+        }
+
+        [Test]
+        public void CookieWithNoPath_PathIsForwardSlash()
+        {
+            const string testDomain = "test.com";
+            const string cookieHeader = "sessionToken=abc123";
+            var actual = SetCookieHeaderParser.GetAllCookiesFromHeader(testDomain, cookieHeader);
+            Assert.That(actual[0].Path, Is.EqualTo("/"));
+        }
+
+        [Test]
+        public void CookieWithPath_UsesAssignedPath()
+        {
+            const string testDomain = "test.com";
+            const string cookieHeader = "sessionToken=abc123; Path=/test/path";
+            var actual = SetCookieHeaderParser.GetAllCookiesFromHeader(testDomain, cookieHeader);
+            Assert.That(actual[0].Path, Is.EqualTo("/test/path"));
+        }
+
+        [Test]
+        public void KeyValueCookieWithExpiresAttribute_DisregardsExpiresValue()
+        {
+            const string cookieHeader = "sessionToken=abc123; Expires=Wed, 09 Jun 2021 10:18:14 GMT";
+            var actual = SetCookieHeaderParser.GetAllCookiesFromHeader("test.com", cookieHeader);
+            Assert.That(actual.Count, Is.EqualTo(1));
+            Assert.That(actual[0].Name, Is.EqualTo("sessionToken"));
+            Assert.That(actual[0].Value, Is.EqualTo("abc123"));
+            Assert.That(actual[0].Expires, Is.EqualTo(DateTime.MinValue));
+        }
+
+        [Test]
+        public void KeyOnlyCookieWithExpiresAttribute_DisregardsExpiresValue()
+        {
+            const string cookieHeader = "sessionToken; Expires=Wed, 09 Jun 2021 10:18:14 GMT";
+            var actual = SetCookieHeaderParser.GetAllCookiesFromHeader("test.com", cookieHeader);
+            Assert.That(actual.Count, Is.EqualTo(1));
+            Assert.That(actual[0].Name, Is.EqualTo("sessionToken"));
+            Assert.That(actual[0].Value, Is.EqualTo(""));
+            Assert.That(actual[0].Expires, Is.EqualTo(DateTime.MinValue));
+        }
+
+        [Test]
+        public void CommaSeparatedCookies_AreReadAsMultipleCookies()
+        {
+            const string cookieHeader = "key1=value1; Expires=Test, TestDate, key2=value2";
+            var actual = SetCookieHeaderParser.GetAllCookiesFromHeader("test.com", cookieHeader);
+            Assert.That(actual.Count, Is.EqualTo(2));
+            Assert.That(actual[0].Name, Is.EqualTo("key1"));
+            Assert.That(actual[0].Value, Is.EqualTo("value1"));
+            Assert.That(actual[1].Name, Is.EqualTo("key2"));
+            Assert.That(actual[1].Value, Is.EqualTo("value2"));
+        }
+
+        [Test]
+        public void CookieContainingCommaValue_IsReadAsASingleCookie()
+        {
+            const string cookieHeader = "key=\"value1, value2\"";
+            var actual = SetCookieHeaderParser.GetAllCookiesFromHeader("test.com", cookieHeader);
+            Assert.That(actual.Count, Is.EqualTo(1));
+            Assert.That(actual[0].Name, Is.EqualTo("key"));
+            Assert.That(actual[0].Value, Is.EqualTo("value1, value2"));
+        }
+
+        [Test]
+        public void ComplexFacebookCookie_DoesNotThrowException()
+        {
+            const string cookieHeader =
+                "datr=80gTVQMaYfPPoOakoxDXhrmQ; expires=Fri, 24-Mar-2017 23:46:59 GMT; Max-Age=63072000; path=/; domain=.facebook.com; httponly,reg_ext_ref=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0; path=/; domain=.facebook.com,reg_fb_ref=https%3A%2F%2Fwww.facebook.com%2F; path=/; domain=.facebook.com; httponly,reg_fb_gate=https%3A%2F%2Fwww.facebook.com%2F; path=/; domain=.facebook.com; httponly";
+            var actual = SetCookieHeaderParser.GetAllCookiesFromHeader("test.com", cookieHeader);
+        }
+    }
+}

--- a/SimpleBrowser.UnitTests/SimpleBrowser.UnitTests.csproj
+++ b/SimpleBrowser.UnitTests/SimpleBrowser.UnitTests.csproj
@@ -50,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Helper.cs" />
+    <Compile Include="InternalTests\SetCookieHeaderParserTests.cs" />
     <Compile Include="Issues.cs" />
     <Compile Include="OfflineTests\FileUri.cs" />
     <Compile Include="OfflineTests\Namespace.cs" />

--- a/SimpleBrowser/Internal/SetCookieHeaderParser.cs
+++ b/SimpleBrowser/Internal/SetCookieHeaderParser.cs
@@ -1,11 +1,5 @@
-﻿// Shamelessly stolen from:
-// http://stackoverflow.com/questions/4792638/mapping-header-cookie-string-to-cookiecollection-and-vice-versa
-// http://snipplr.com/view/4427/
-
-namespace SimpleBrowser.Internal
+﻿namespace SimpleBrowser.Internal
 {
-	using System;
-	using System.Collections;
 	using System.Net;
 	using System.Text;
 
@@ -17,180 +11,199 @@ namespace SimpleBrowser.Internal
 		/// <summary>
 		/// Parses the set-cookie HTTP header.
 		/// </summary>
-		/// <param name="strHost">The host sending the header.</param>
-		/// <param name="strHeader">The-set cookie header received from the host.</param>
+		/// <param name="defaultHost">The host sending the header.</param>
+		/// <param name="header">The-set cookie header received from the host.</param>
 		/// <returns></returns>
-		public static CookieCollection GetAllCookiesFromHeader(string strHost, string strHeader)
+		public static CookieCollection GetAllCookiesFromHeader(string defaultHost, string header)
 		{
-			ArrayList al = new ArrayList();
-			CookieCollection cc = new CookieCollection();
-			if (strHeader != string.Empty)
-			{
-				al = ConvertCookieHeaderToArrayList(strHeader);
-				cc = ConvertCookieArraysToCookieCollection(al, strHost);
-			}
+            header = header.Replace("\r", "");
+            header = header.Replace("\n", "");
+            int index = 0;
+            CookieCollection cc = new CookieCollection();
+            while (index < header.Length)
+		    {
+		        index = ParseCookie(header, index, cc, defaultHost);
+		    }
 			return cc;
 		}
 
-		/// <summary>
-		/// Converts a set-cookie header into a collection of its component parts as strings.
-		/// </summary>
-		/// <param name="strCookHeader">The set-cookie header to convert.</param>
-		/// <returns>A collection of string components of the header</returns>
-		private static ArrayList ConvertCookieHeaderToArrayList(string strCookHeader)
-		{
-			strCookHeader = strCookHeader.Replace("\r", "");
-			strCookHeader = strCookHeader.Replace("\n", "");
-			string[] strCookTemp = strCookHeader.Split(',');
-			ArrayList al = new ArrayList();
-			int i = 0;
-			int n = strCookTemp.Length;
-			while (i < n)
-			{
-				if (strCookTemp[i].IndexOf("expires=", StringComparison.OrdinalIgnoreCase) > 0)
-				{
-					al.Add(strCookTemp[i] + "," + strCookTemp[i + 1]);
-					i = i + 1;
-				}
-				else
-				{
-					al.Add(strCookTemp[i]);
-				}
-				i = i + 1;
-			}
-			return al;
-		}
+	    private static int ParseCookie(string header, int beginIndex, CookieCollection cc, string defaultHost)
+	    {
+            int index = beginIndex;
 
-		/// <summary>
-		/// Converts a collection of component string parts into a CookeCollection of cookies.
-		/// </summary>
-		/// <param name="al">The collection of set cookie header string components</param>
-		/// <param name="strHost">The host sending the header</param>
-		/// <returns>A CookieCollection</returns>
-		private static CookieCollection ConvertCookieArraysToCookieCollection(ArrayList al, string strHost)
-		{
-			CookieCollection cc = new CookieCollection();
+	        var cookie = new Cookie();
+            index = ParseKeyValueFragment(header, index, cookie);
+	        while (index < header.Length && header[index] == ';')
+	        {
+	            index = ParseCookieAttribute(header, index+1, cookie);
+	        }
+            index++;
 
-			int alcount = al.Count;
-			string strEachCook;
-			string[] strEachCookParts;
-			for (int i = 0; i < alcount; i++)
-			{
-				strEachCook = al[i].ToString();
-				strEachCookParts = strEachCook.Split(';');
-				int intEachCookPartsCount = strEachCookParts.Length;
-				string strCNameAndCValue = string.Empty;
-				string strPNameAndPValue = string.Empty;
-				string[] NameValuePairTemp;
-				Cookie cookTemp = new Cookie();
+            if (cookie.Domain == string.Empty)
+            {
+                cookie.Domain = defaultHost;
+            }
+            if (cookie.Path == string.Empty)
+            {
+                cookie.Path = "/";
+            }
 
-				for (int j = 0; j < intEachCookPartsCount; j++)
-				{
-					if (j == 0)
-					{
-						strCNameAndCValue = strEachCookParts[j];
-						if (strCNameAndCValue != string.Empty)
-						{
-							int firstEqual = strCNameAndCValue.IndexOf("=");
-							string firstName = strCNameAndCValue.Substring(0, firstEqual);
-							string allValue = strCNameAndCValue.Substring(firstEqual + 1, strCNameAndCValue.Length - (firstEqual + 1));
-							cookTemp.Name = EncodeCookieName(firstName);
-							cookTemp.Value = allValue;
-						}
+            cc.Add(cookie);
+            return index;
+        }
 
-						continue;
-					}
+	    private static int ParseKeyValueFragment(string header, int beginIndex, Cookie cookie)
+	    {
+	        int index = beginIndex;
+	        while (index < header.Length)
+	        {
+	            switch (header[index])
+	            {
+	                case '=':
+	                    cookie.Name = EncodeCookieName(header.Substring(beginIndex, index - beginIndex).Trim());
+	                    string value;
+	                    index = ParseValue(header, index+1, out value);
+	                    cookie.Value = value;
+	                    return index;
+                    case ',':
+                    case ';':
+                        var parsedValue = header.Substring(beginIndex, index - beginIndex).Trim();
+                        cookie.Name = parsedValue;
+	                    return index;
+	            }
 
-					if (strEachCookParts[j].IndexOf("path", StringComparison.OrdinalIgnoreCase) >= 0)
-					{
-						strPNameAndPValue = strEachCookParts[j];
-						if (strPNameAndPValue != string.Empty)
-						{
-							NameValuePairTemp = strPNameAndPValue.Split('=');
-							if (NameValuePairTemp[1] != string.Empty)
-							{
-								cookTemp.Path = NameValuePairTemp[1];
-							}
-							else
-							{
-								cookTemp.Path = "/";
-							}
-						}
+	            index++;
+	        }
+	        cookie.Name = header.Substring(beginIndex);
+	        return index;
+	    }
 
-						continue;
-					}
+        private static int ParseCookieAttribute(string header, int beginIndex, Cookie cookie)
+        {
+	        int index = beginIndex;
+            while (index < header.Length)
+            {
+                switch (header[index])
+                {
+                    case '=':
+                        string attributeName = header.Substring(beginIndex, index - beginIndex).Trim();
+                        if (attributeName.ToLower() == "expires")
+                        {
+                            return ParseExpiresValue(header, index+1, cookie);
+                        }
+                        else
+                        {
+                            string value;
+                            index = ParseValue(header, index+1, out value);
+                            if (attributeName.ToLower() == "domain")
+                            {
+                                cookie.Domain = value;
+                            }
+                            else if (attributeName.ToLower() == "path")
+                            {
+                                cookie.Path = value;
+                            }
+                            return index;
+                        }
+                    case ',':
+                    case ';':
+                        return index;
+                }
 
-					if (strEachCookParts[j].IndexOf("domain", StringComparison.OrdinalIgnoreCase) >= 0)
-					{
-						strPNameAndPValue = strEachCookParts[j];
-						if (strPNameAndPValue != string.Empty)
-						{
-							NameValuePairTemp = strPNameAndPValue.Split('=');
+                index++;
+            }
 
-							if (NameValuePairTemp[1] != string.Empty)
-							{
-								cookTemp.Domain = NameValuePairTemp[1];
-							}
-							else
-							{
-								cookTemp.Domain = strHost;
-							}
-						}
+            return index;
+        }
 
-						continue;
-					}
-				}
+	    private static int ParseValue(string header, int beginIndex, out string value)
+	    {
+	        int index = beginIndex;
+	        bool isQuoted = false;
+	        while (index < header.Length)
+	        {
+	            switch (header[index])
+	            {
+                    case ',':
+	                case ';':
+	                    if (isQuoted == false)
+	                    {
+	                        value = header.Substring(beginIndex, index - beginIndex);
+	                        value = value.TrimStart('"').TrimEnd('"');
+	                        return index;
+	                    }
+	                    break;
+                    case '"':
+	                    isQuoted = !isQuoted;
+	                    break;
+	            }
+	            index++;
+	        }
+            value = header.Substring(beginIndex, index - beginIndex);
+            value = value.TrimStart('"').TrimEnd('"');
+            return index;
+        }
 
-				if (cookTemp.Path == string.Empty)
-				{
-					cookTemp.Path = "/";
-				}
+	    private static int ParseExpiresValue(string header, int beginIndex, Cookie cookie)
+	    {
+	        int index = beginIndex;
+	        int noCommas = 0;
+	        while (index < header.Length)
+	        {
+	            switch (header[index])
+	            {
+	                case ',':
+	                    if (noCommas == 0)
+	                    {
+	                        noCommas++;
+	                    }
+	                    else
+	                    {
+                            return index;
+                        }
+	                    break;
+	                case ';':
+                        return index;
+                }
+	            index++;
+	        }
+	        return index;
+	    }
 
-				if (cookTemp.Domain == string.Empty)
-				{
-					cookTemp.Domain = strHost;
-				}
+        /// <summary>
+        /// Encodes the cookie name (key) so that it contains only valid characters.
+        /// </summary>
+        /// <param name="name">The name to encode</param>
+        /// <remarks>
+        /// This method is essentially URL encoding, but only encodes the characters that are invalid
+        /// for a cookie name, as defined by the .NET Framework 4 documentation of the System.Net.Cookie.Name
+        /// property, specifically:
+        /// 
+        /// "The following characters must not be used inside the Name property: equal sign, semicolon,
+        /// comma, newline (\n), return (\r), tab (\t), and space character. The dollar sign character
+        /// ("$") cannot be the first character."
+        ///
+        /// Note: In true Microsoft fashion, this this differs from what is defined in RFC 2616, section 2.2.
+        /// RFC 2616 specifies 51 characters that are technically not allowed to be in a cookie name.
+        /// </remarks>
+        /// <returns>The encoded cookie name.</returns>
+        private static string EncodeCookieName(string name)
+        {
+            StringBuilder validName = new StringBuilder(name);
+            validName.Replace("=", "%3D");
+            validName.Replace(";", "%3B");
+            validName.Replace(",", "%2C");
+            validName.Replace("\n", "%10");
+            validName.Replace("\r", "%13");
+            validName.Replace("\t", "%09");
+            validName.Replace(" ", "%20");
 
-				cc.Add(cookTemp);
-			}
+            if (name.StartsWith("$"))
+            {
+                validName.Replace("$", "%24", 0, 1);
+            }
 
-			return cc;
-		}
-
-		/// <summary>
-		/// Encodes the cookie name (key) so that it contains only valid characters.
-		/// </summary>
-		/// <param name="name">The name to encode</param>
-		/// <remarks>
-		/// This method is essentially URL encoding, but only encodes the characters that are invalid
-		/// for a cookie name, as defined by the .NET Framework 4 documentation of the System.Net.Cookie.Name
-		/// property, specifically:
-		/// 
-		/// "The following characters must not be used inside the Name property: equal sign, semicolon,
-		/// comma, newline (\n), return (\r), tab (\t), and space character. The dollar sign character
-		/// ("$") cannot be the first character."
-		///
-		/// Note: In true Microsoft fashion, this this differs from what is defined in RFC 2616, section 2.2.
-		/// RFC 2616 specifies 51 characters that are technically not allowed to be in a cookie name.
-		/// </remarks>
-		/// <returns>The encoded cookie name.</returns>
-		private static string EncodeCookieName(string name)
-		{
-			StringBuilder validName = new StringBuilder(name);
-			validName.Replace("=", "%3D");
-			validName.Replace(";", "%3B");
-			validName.Replace(",", "%2C");
-			validName.Replace("\n", "%10");
-			validName.Replace("\r", "%13");
-			validName.Replace("\t", "%09");
-			validName.Replace(" ", "%20");
-
-			if (name.StartsWith("$"))
-			{
-				validName.Replace("$", "%24", 0, 1);
-			}
-
-			return validName.ToString();
-		}
+            return validName.ToString();
+        }
 	}
 }


### PR DESCRIPTION
Rewritten cookie header handling to handle cookies containing commas in values, also code is now test-driven so changes / defects can be handled without breaking existing functionality.